### PR TITLE
Make value of PickerItem component flexible

### DIFF
--- a/src/picker.js
+++ b/src/picker.js
@@ -54,7 +54,7 @@ export default class Picker extends Component {
         {pickerData.map((data, index) => (
           <PickerItem
             key={index}
-            value={data.value || data}
+            value={typeof data.value !== 'undefined' ? data.value : data}
             label={data.label || data.toString()}
           />
         ))}


### PR DESCRIPTION
if data.value is 0, then PickerItem will have an empty object.

ex)
input: [{label:'A', value: 0}, {label:'B', value: 1}]
output: [{}, {label:'B', value: 1}]
