### PR TITLE
add componentWillReceiveProps to picker

### DIFF
--- a/src/picker.js
+++ b/src/picker.js
@@ -44,6 +44,10 @@ export default class Picker extends Component {
     this.props.onValueChange(selectedValue);
   };
 
+  componentWillReceiveProps({ selectedValue }) {
+    this.setState({ selectedValue });
+  }
+
   render() {
     const { pickerData, style, ...props } = this.props;
 


### PR DESCRIPTION
Currently You cannot change the selectedValue from outside the picker,
see example of the issue:
```js
class myComponent {
   constructor() {
       this.state = { value: 1}
   }

   inc() {
        this.setState({value: value + 1})
   }

    render() {
        <View>
            <Button onPress={this.inc.bind(this)}> Change selected value </Button>
             <Picker selectedValue={this.state.value}
                  pickerData= {[1,2,3,4 ....]}
        </View>
    }
}
```