### PR TITLE
Receive props android fix

### DIFF
--- a/src/date-picker.android.js
+++ b/src/date-picker.android.js
@@ -28,6 +28,7 @@ export default class DatePicker extends PureComponent {
       month: PropTypes.string,
       date: PropTypes.string,
     }),
+    order: PropTypes.string,
     date: PropTypes.instanceOf(Date).isRequired,
     maximumDate: PropTypes.instanceOf(Date),
     minimumDate: PropTypes.instanceOf(Date),
@@ -41,6 +42,7 @@ export default class DatePicker extends PureComponent {
 
   static defaultProps = {
     labelUnit: { year: '', month: '', date: '' },
+    order: 'D-M-Y',
     mode: 'date',
     maximumDate: moment().add(10, 'years').toDate(),
     minimumDate: moment().add(-10, 'years').toDate(),
@@ -160,39 +162,55 @@ export default class DatePicker extends PureComponent {
   get datePicker() {
     const propsStyles = stylesFromProps(this.props);
 
-    return [
-      <View key='year' style={styles.picker}>
-        <Picker
-          {...propsStyles}
-          style={this.props.style}
-          ref={(year) => { this.yearComponent = year; }}
-          selectedValue={this.state.date.getFullYear()}
-          pickerData={this.state.yearRange}
-          onValueChange={this.onYearChange}
-        />
-      </View>,
-      <View key='month' style={styles.picker}>
-        <Picker
-          {...propsStyles}
-          style={this.props.style}
-          ref={(month) => { this.monthComponent = month; }}
-          selectedValue={this.state.date.getMonth() + 1}
-          pickerData={this.state.monthRange}
-          onValueChange={this.onMonthChange}
-        />
-      </View>,
-      <View key='date' style={styles.picker}>
-        <Picker
-          {...propsStyles}
-          style={this.props.style}
-          ref={(date) => { this.dateComponent = date; }}
-          selectedValue={this.state.date.getDate()}
-          pickerData={this.state.dayRange}
-          onValueChange={this.onDateChange}
-        />
-      </View>,
-    ];
+    const { order } = this.props;
+
+    if (!order.includes('D') && !order.includes('M') && !order.includes('Y')) {
+      throw new Error(`WheelDatePicker: you are using order prop wrong, default value is 'D-M-Y'`);
+    }
+
+    return this.props.order.split('-').map((key) => {
+      switch (key) {
+        case 'D': return (
+          <View key='date' style={styles.picker}>
+            <Picker
+              {...propsStyles}
+              style={this.props.style}
+              ref={(date) => { this.dateComponent = date; }}
+              selectedValue={this.state.date.getDate()}
+              pickerData={this.state.dayRange}
+              onValueChange={this.onDateChange}
+            />
+          </View>
+        );
+        case 'M': return (
+          <View key='month' style={styles.picker}>
+            <Picker
+              {...propsStyles}
+              style={this.props.style}
+              ref={(month) => { this.monthComponent = month; }}
+              selectedValue={this.state.date.getMonth() + 1}
+              pickerData={this.state.monthRange}
+              onValueChange={this.onMonthChange}
+            />
+          </View>
+        );
+        case 'Y': return (
+          <View key='year' style={styles.picker}>
+            <Picker
+              {...propsStyles}
+              style={this.props.style}
+              ref={(year) => { this.yearComponent = year; }}
+              selectedValue={this.state.date.getFullYear()}
+              pickerData={this.state.yearRange}
+              onValueChange={this.onYearChange}
+            />
+          </View>
+        );
+        default: return null;
+      }
+    })
   }
+
   get timePicker() {
     const propsStyles = stylesFromProps(this.props);
 

--- a/src/date-picker.android.js
+++ b/src/date-picker.android.js
@@ -54,32 +54,56 @@ export default class DatePicker extends PureComponent {
   constructor(props) {
     super(props);
 
+    const {
+      date,
+      minimumDate,
+      maximumDate,
+      labelUnit,
+    } = props;
+
     this.state = {
-      date: this.props.date,
+      date,
       monthRange: [],
       yearRange: [],
     };
 
-    const date = moment(this.state.date);
     this.newValue = {};
 
-    ['year', 'month', 'date', 'hour', 'minute'].forEach((s) => { this.newValue[s] = date.get(s); });
+    this._parseDate(date);
 
-    const dayNum = date.daysInMonth();
+    const mdate = moment(date);
+
+    const dayNum = mdate.daysInMonth();
     this.state.dayRange = this.genDateRange(dayNum);
 
-    const minYear = this.props.minimumDate.getFullYear();
-    const maxYear = this.props.maximumDate.getFullYear();
+    const minYear = minimumDate.getFullYear();
+    const maxYear = maximumDate.getFullYear();
 
     for (let i = 1; i <= 12; i += 1) {
-      this.state.monthRange.push({ value: i, label: `${i}${this.props.labelUnit.month}` });
+      this.state.monthRange.push({ value: i, label: `${i}${labelUnit.month}` });
     }
 
-    this.state.yearRange.push({ value: minYear, label: `${minYear}${this.props.labelUnit.year}` });
+    this.state.yearRange.push({ value: minYear, label: `${minYear}${labelUnit.year}` });
 
     for (let i = minYear + 1; i <= maxYear; i += 1) {
-      this.state.yearRange.push({ value: i, label: `${i}${this.props.labelUnit.year}` });
+      this.state.yearRange.push({ value: i, label: `${i}${labelUnit.year}` });
     }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.state.date !== nextProps.date) {
+      this._parseDate(nextProps.date);
+
+      this.setState({
+        date: nextProps.date,
+      });
+    }
+  }
+
+  _parseDate = (date) => {
+    const mdate = moment(date);
+
+    ['year', 'month', 'date', 'hour', 'minute'].forEach((s) => { this.newValue[s] = mdate.get(s); });
   }
 
   onYearChange = (year) => {


### PR DESCRIPTION
Controlled component pattern doesn't work for android, this PR fixed this!

Also added new prop `order` to have ability ordering internal pickers (default value is `D-M-Y`, same as on iOS)